### PR TITLE
FFMT-5114 Disable JPA auditing in KJAR deployment descriptor

### DIFF
--- a/src/main/resources/META-INF/kie-deployment-descriptor.xml
+++ b/src/main/resources/META-INF/kie-deployment-descriptor.xml
@@ -2,7 +2,7 @@
 <deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <persistence-unit>org.jbpm.domain</persistence-unit>
     <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
-    <audit-mode>JPA</audit-mode>
+    <audit-mode>NONE</audit-mode>
     <persistence-mode>JPA</persistence-mode>
     <runtime-strategy>PER_PROCESS_INSTANCE</runtime-strategy>
     <marshalling-strategies/>


### PR DESCRIPTION
Disable JPA auditing at the KJAR level to match the server-level audit mode configuration. This eliminates synchronous database writes for audit logging during high-throughput batch imports of shipment resources.

The kibo-fulfillment-workflows system only uses active process instances, and historical data is synchronized to MongoDB. No application code depends on jBPM audit tables for production logic.

Performance Impact:
- Eliminates lock contention on audit tables
- Reduces database I/O during batch shipment creation
- Improves throughput for high-volume imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)